### PR TITLE
Support s3 data repository in dynamic provision

### DIFF
--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -1,4 +1,4 @@
-** github.com/aws/aws-sdk-go; version 1.16.5 -- https://github.com/aws/aws-sdk-go
+** github.com/aws/aws-sdk-go; version 1.16.36 -- https://github.com/aws/aws-sdk-go
 ** github.com/container-storage-interface/spec; version v0.3.0 -- https://github.com/container-storage-interface/spec/
 ** github.com/golang/mock; version v1.2.0 -- https://github.com/golang/mock
 ** github.com/kubernetes-csi/csi-test; version v0.3.0-2 -- https://github.com/kubernetes-csi/csi-test

--- a/examples/kubernetes/dynamic_provisioning_s3/README.md
+++ b/examples/kubernetes/dynamic_provisioning_s3/README.md
@@ -1,0 +1,79 @@
+## Dynamic Provisioning with data repository Example
+This example shows how to create a FSx for Lustre filesystem using persistence volume claim (PVC) with data repository integration.
+
+Amazon FSx for Lustre is deeply integrated with Amazon S3. This integration means that you can seamlessly access the objects stored in your Amazon S3 buckets from applications mounting your Amazon FSx for Lustre file system. Please check [Using Data Repositories](https://docs.aws.amazon.com/fsx/latest/LustreGuide/fsx-data-repositories.html) for details.
+
+### Edit [StorageClass](storageclass.yaml)
+```
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fsx-sc
+provisioner: fsx.csi.aws.com
+parameters:
+  subnetId: subnet-056da83524edbe641
+  securityGroupIds: sg-086f61ea73388fb6b
+  s3ImportPath: s3://dl-benchmark-dataset
+  s3ExportPath: s3://dl-benchmark-dataset/export
+```
+* subnetId - the subnet ID that the FSx for Lustre filesystem should be created inside.
+* securityGroupIds - a comman separated list of security group IDs that should be attached to the filesystem
+* s3ImportPath(Optional) - S3 data repository you want to copy from S3 to persistent volume
+* s3ExportPath(Optional) - S3 data repository you want to export new or modified files from persistent volume to S3
+
+Note:
+- S3Bucket in s3ImportPath and s3ExportPath must be same, otherwise aws-fsx-csi-driver can not create FSx for lustre successfully.
+- S3ExportPath can not be given without specifying S3ImportPath.
+- S3ImportPath can stand alone and a random path will be created automatically like `s3://dl-benchmark-result/FSxLustre20190308T012310Z`
+
+### Edit [Persistent Volume Claim Spec](claim.yaml)
+```
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fsx-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: fsx-sc
+  resources:
+    requests:
+      storage: 5Gi
+```
+Update `spec.resource.requests.storage` with the storage capacity to request. The storage capacity value will be rounded up multiplication of 3600GiB.
+
+### Deploy the Application
+Create PVC, storageclass and the pod that consumes the PV:
+```sh
+>> kubectl apply -f examples/kubernetes/dynamic_provisioning/storageclass.yaml
+>> kubectl apply -f examples/kubernetes/dynamic_provisioning/claim.yaml
+>> kubectl apply -f examples/kubernetes/dynamic_provisioning/pod.yaml
+```
+
+### Use Case 1: Acccess S3 files in readonly mode, no write back.
+If you only want to import data and read it with any modification and creation. You can skip `s3ExportPath` parameter in your `storageclass.yaml` configuration.
+
+You can see S3 files have been downloaded in the persistent volume.
+
+```
+kubectl exec -it fsx-app ls /data
+```
+
+### Use case 2: Sync back new created files to s3ExportPath
+
+Pod `fsx-app` create a file `out.txt` in mounted volume, you can run following command to check this file.
+
+```
+kubectl exec -ti fsx-app -- tail -f /data/out.txt
+```
+
+### Use case 3: Sync back modified S3 files to s3ExportPath
+Making change to S3 files is allowed but original files in S3 won't be updated. Instead, FSx allows you to sync these changes back to s3ExportPath.
+
+### Sync files
+New created and modified files won't be synced back to S3 automatically. In order to sync files to `S3ExportPath`, you need to install lustre client in your container image and manually run following command to force sync up.
+
+```
+sudo lfs hsm_archive /data/out.txt
+sudo lfs hsm_run /data/out.txt
+```

--- a/examples/kubernetes/dynamic_provisioning_s3/claim.yaml
+++ b/examples/kubernetes/dynamic_provisioning_s3/claim.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fsx-claim
+spec:
+  accessModes:
+    - ReadWriteMany
+  storageClassName: fsx-sc
+  resources:
+    requests:
+      storage: 5Gi

--- a/examples/kubernetes/dynamic_provisioning_s3/pod.yaml
+++ b/examples/kubernetes/dynamic_provisioning_s3/pod.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: fsx-app
+spec:
+  containers:
+  - name: app
+    image: chengpan/aws-fsx-csi-driver:testing
+    command: ["/bin/sh"]
+    args: ["-c", "while true; do echo $(date -u) >> /data/out.txt; sleep 5; done"]
+    volumeMounts:
+    - name: persistent-storage
+      mountPath: /data
+  volumes:
+  - name: persistent-storage
+    persistentVolumeClaim:
+      claimName: fsx-claim

--- a/examples/kubernetes/dynamic_provisioning_s3/storageclass.yaml
+++ b/examples/kubernetes/dynamic_provisioning_s3/storageclass.yaml
@@ -1,0 +1,10 @@
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: fsx-sc
+provisioner: fsx.csi.aws.com
+parameters:
+  subnetId: subnet-0cd89fc1c1bc6ef51
+  securityGroupIds: sg-0afdb18c8af898a78
+  s3ImportPath: s3://dl-benchmark-result
+  s3OutputPath: s3://dl-benchmark-result/export

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/kubernetes-sigs/aws-fsx-csi-driver
 
 require (
-	github.com/aws/aws-sdk-go v1.16.5
+	github.com/aws/aws-sdk-go v1.16.36
 	github.com/container-storage-interface/spec v0.3.0
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/golang/mock v1.2.0

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/davecgh/go-spew v1.1.0 // indirect
 	github.com/golang/mock v1.2.0
 	github.com/kubernetes-csi/csi-test v0.3.0-2
+	github.com/mattn/goveralls v0.0.2 // indirect
 	github.com/onsi/ginkgo v1.7.0
 	github.com/onsi/gomega v1.4.3
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 github.com/aws/aws-sdk-go v1.16.5 h1:NVxzZXIuwX828VcJrpNxxWjur1tlOBISdMdDdHIKHcc=
 github.com/aws/aws-sdk-go v1.16.5/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/aws/aws-sdk-go v1.16.36 h1:POeH34ZME++pr7GBGh+ZO6Y5kOwSMQpqp5BGUgooJ6k=
+github.com/aws/aws-sdk-go v1.16.36/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/container-storage-interface/spec v0.3.0 h1:ALxSqFjptj8R5rL+cdyAbwbaLHHXDL5pmp1qIh1b+38=
 github.com/container-storage-interface/spec v0.3.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/kubernetes-csi/csi-test v0.3.0-2 h1:RsVmFc3AlpjQdyfMKiphvd8igXwOI7lQgWo+kJAh49c=
 github.com/kubernetes-csi/csi-test v0.3.0-2/go.mod h1:YxJ4UiuPWIhMBkxUKY5c267DyA0uDZ/MtAimhx/2TA0=
+github.com/mattn/goveralls v0.0.2 h1:7eJB6EqsPhRVxvwEXGnqdO2sJI0PTsrWoTMXEk9/OQc=
+github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.7.0 h1:WSHQ+IS43OoUrWtD1/bbclrwK8TTH5hzp+umCiuxHgs=
 github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -41,6 +43,7 @@ golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e h1:o3PsSEY8E4eXWkXrIP9YJALUk
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52 h1:JG/0uqcGdTNgq7FdU+61l5Pdmb8putNZlXb65bJBROs=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8 h1:Nw54tB0rB7hY/N0NQvRW8DG4Yk3Q6T9cu9RcFQDu1tc=

--- a/pkg/cloud/mocks/mock_fsx.go
+++ b/pkg/cloud/mocks/mock_fsx.go
@@ -5,11 +5,12 @@
 package mocks
 
 import (
+	reflect "reflect"
+
 	aws "github.com/aws/aws-sdk-go/aws"
 	request "github.com/aws/aws-sdk-go/aws/request"
 	fsx "github.com/aws/aws-sdk-go/service/fsx"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
 // MockFSx is a mock of FSx interface

--- a/pkg/driver/controller.go
+++ b/pkg/driver/controller.go
@@ -69,6 +69,15 @@ func (d *Driver) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest)
 		SubnetId:         subnetId,
 		SecurityGroupIds: strings.Split(securityGroupIds, ","),
 	}
+
+	if val, ok := volumeParams["s3ImportPath"]; ok {
+		fsOptions.S3ImportPath = val
+	}
+
+	if val, ok := volumeParams["s3ExportPath"]; ok {
+		fsOptions.S3ExportPath = val
+	}
+
 	fs, err := d.cloud.CreateFileSystem(ctx, volName, fsOptions)
 	if err != nil {
 		switch err {

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -66,3 +66,14 @@ func ParseEndpoint(endpoint string) (string, string, error) {
 func roundUpSize(volumeSizeBytes int64, allocationUnitBytes int64) int64 {
 	return (volumeSizeBytes + allocationUnitBytes - 1) / allocationUnitBytes
 }
+
+// GetURLHost returns hostname  of given url
+func GetURLHost(urlStr string) (string, error) {
+	u, err := url.Parse(urlStr)
+
+	if err != nil {
+		return "", fmt.Errorf("Could not parse url: %v", err)
+	}
+
+	return u.Host, nil
+}

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package util
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestGiBToBytes(t *testing.T) {
 	var sizeInGiB int64 = 3
@@ -65,6 +67,35 @@ func TestRoundUp3600GiB(t *testing.T) {
 			actual := RoundUp3600GiB(tc.sizeInBytes)
 			if actual != tc.expected {
 				t.Fatalf("RoundUp3600GiB got wrong result. actual: %d, expected: %d", actual, tc.expected)
+			}
+		})
+	}
+}
+
+func TestGetURLHost(t *testing.T) {
+	testCases := []struct {
+		name     string
+		url      string
+		expected string
+	}{
+		{
+			name:     "GetURLHost host without path",
+			url:      "s3://fs-s3-data-repo",
+			expected: "fs-s3-data-repo",
+		},
+		{
+			name:     "GetURLHost standard url",
+			url:      "s3://fs-s3-data-repo/import-path",
+			expected: "fs-s3-data-repo",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, _ := GetURLHost(tc.url)
+
+			if actual != tc.expected {
+				t.Fatalf("GetURLHost got wrong result. actual: %s, expected: %s", actual, tc.expected)
 			}
 		})
 	}


### PR DESCRIPTION
**Is this a bug fix or adding new feature?**
/feature

Fixes: #16 

**What is this PR about? / Why do we need it?**
Enable S3 data repository integration when creating FSx for Lustre

**What testing is done?** 
UT and manual testing. 

Chunk size is not in this PR yet. I explained reason in #16. If there's use case, I will file another PR to support it. 
